### PR TITLE
fix: double slash in fetch backend path construction

### DIFF
--- a/lib/backends/fetch.js
+++ b/lib/backends/fetch.js
@@ -28,7 +28,8 @@ class FetchClient {
   http (options) {
     const body = JSON.stringify(options.body)
     const url = new URL(this.url)
-    url.pathname += options.pathname
+    // trim trailing slashes
+    url.pathname = url.pathname.replace(/\/$/, '') + options.pathname
     const searchParams = new URLSearchParams(options.parameters || options.qs)
     url.search = searchParams
 


### PR DESCRIPTION
in my case `url.pathname` was '/', which resulted in a double forward slash at the root of the path