### PR TITLE
fix(loader): use isPlainObject when merging.

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -23,6 +23,7 @@
  */
 
 const merge = require('deepmerge')
+const isPlainObject = require('is-plain-object')
 
 class Endpoint {
   /**
@@ -283,7 +284,7 @@ class Component {
   _patch (options) {
     return this._requestAsync('PATCH', merge({
       headers: { 'content-type': 'application/strategic-merge-patch+json' }
-    }, options))
+    }, options, { isMergeableObject: isPlainObject }))
   }
 
   /**
@@ -294,7 +295,7 @@ class Component {
   _post (options) {
     return this._requestAsync('POST', merge({
       headers: { 'content-type': 'application/json' }
-    }, options))
+    }, options, { isMergeableObject: isPlainObject }))
   }
 
   /**
@@ -305,7 +306,7 @@ class Component {
   _put (options) {
     return this._requestAsync('PUT', merge({
       headers: { 'content-type': 'application/json' }
-    }, options))
+    }, options, { isMergeableObject: isPlainObject }))
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2426,6 +2426,14 @@
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
+    "is-plain-object": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+      "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+      "requires": {
+        "isobject": "^4.0.0"
+      }
+    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
@@ -2487,6 +2495,11 @@
       "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "isobject": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+      "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
     },
     "isstream": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "deepmerge": "^4.2.2",
+    "is-plain-object": "^3.0.0",
     "request": "^2.88.0"
   }
 }


### PR DESCRIPTION
Earlier this week, one of my modules, the [openshift-rest-client](https://github.com/nodeshift/openshift-rest-client/issues/209), which is built on top of the kubernetes-client, started to break when uploading a binary file.  Basically, we create a readStream from a local file using `fs.createReadStream` which gets added to the request body

The error was happening in the Request module, at the point where it looks to set the ContentLength,  which is should skip over if the body is a stream.  Code link for reference: https://github.com/request/request/blob/3c0cddc7c8eb60b470e9519da85896ed7ee0081e/request.js#L441

The problem started happening when we upgraded to kubernetes-client@8.3.7,  and after some digging i noticed that the merge libraries where swapped.   Since deepmerge by default clones every object property, it was "stripping" the fact that the object i passed in was a ReadStream

according to the docs, https://www.npmjs.com/package/deepmerge#ismergeableobject , that can be fixed using the "isPlainObject" module when doing merges.

This PR adds the `isPlainObject` module and also adds that third parameter to the merge function calls.

I create a repo where i was basically simulating what was happening to show the difference:  https://github.com/lholmquist/merge-deep-merge-fu