### PR TITLE
fix: only try to expose supported methods

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -220,7 +220,10 @@ class Component {
     //
     // "Expose" operations by omitting the leading _ from the method name.
     //
-    Object.keys(endpoint.pathItem)
+    const supportedMethods = ['get', 'put', 'post', 'delete', 'patch']
+
+    supportedMethods
+      .filter(method => endpoint.pathItem[method])
       .forEach(method => {
         component[method] = component['_' + method]
         if (method === 'get') component.getStream = component._getStream


### PR DESCRIPTION
Test failing here https://github.com/godaddy/kubernetes-client/pull/619 due to pathItems containing the `parameters` object and therefor effectively overriding this with `undefined` (something like `component["parameters"] = component['_' + "parameters"]` ends up happening, and `component["_parameters"]` is of course undefined and shouldn't override the `parameters` prop regardless). 