### PR TITLE
Potential fix for custom metrics endpoints

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -22,306 +22,314 @@
  * [3]: https://swagger.io/specification/#pathsObject
  */
 
-const merge = require('deepmerge')
-const isPlainObject = require('is-plain-object')
+ const merge = require('deepmerge')
+ const isPlainObject = require('is-plain-object')
+ 
+ class Endpoint {
+   /**
+    * Internal representation of a Swagger Path Item Object.
+    * @param {object} options - Options object
+    * @param {string} options.name - Path Item Object name
+    * @param {array} options.splits - Pathname pieces split in '/'
+    * @param {object} options.pathItem - Swagger Path Item Object.
+    */
+   constructor (options) {
+     this.name = options.name
+     this.splits = options.splits
+     this.pathItem = options.pathItem
+   }
+ }
+ 
+ class Component {
+   /**
+    * Represents a single path split, child Components, and potentially a Path
+    * Item Object.
+    * @param {object} options - Options object
+    * @param {object} options.http - Request object
+    * @param {array} options.splits - Absolute pathname (split on '/')
+    * @param {string} options.parameters - Path Template values for parents
+    * @param {string} options.template - Optional Path Template (e.g., {name})
+    */
+   constructor (options) {
+     options = Object.assign({ splits: [], parameters: [] }, options)
+     let component
+ 
+     //
+     // Support Path Templating: use a function to create a a Component-like
+     // object if required. Otherwise use a vanilla object (that isn't callable).
+     //
+     if (options.templated) {
+       component = name => {
+         const splits = component.splits.concat([name])
+         //
+         // Assume that we'll never have a path with adjacent templates.
+         // E.g., assume `/foo/{name}/{property}` cannot exist.
+         //
+         const namedComponent = new this.constructor({
+           backend: component.backend,
+           getNames: options.getNames,
+           splits: splits,
+           parameters: options.parameters.concat([name])
+         })
+         component.templatedEndpoints.forEach(child => {
+           namedComponent._addEndpoint(child)
+         })
+         return namedComponent
+       }
+       component.templatedEndpoints = []
+ 
+       //
+       // Attach methods
+       //
+       Object.setPrototypeOf(component, this.constructor.prototype)
+     } else {
+       component = this
+       component.templatedEndpoints = null
+     }
+ 
+     component.parameters = options.parameters
+     component.templated = options.templated
+     component.splits = options.splits.slice()
+     component.backend = options.backend
+     component.getNames = options.getNames || (split => [split])
+     component.children = []
+     return component
+   }
+ 
+   /**
+    * Get the path.
+    * @returns {string} path with '/' as the separator.
+    */
+   getPath () {
+     return `/${this.splits.join('/')}`
+   }
+ 
+   /**
+    * Return an object of pathname parameters.
+    * @returns {object} object mapping each parameter name to its value.
+    */
+   getPathnameParameters () {
+     const pathnameParameterNames = this.swaggerName
+       .split('/')
+       .filter(component => component.startsWith('{'))
+       .map(component => component.slice(1, -1))
+ 
+     return pathnameParameterNames.reduce((acc, value, index) => {
+       acc[value] = this.parameters[index]
+       return acc
+     }, {})
+   }
+ 
+   /**
+    * Add endpoints defined by a swagger spec to this component. You would
+    * typically call this only on the root component to add API resources. For
+    * example, during client initialization, to extend the client with CRDs.
+    * @param {object} spec - Swagger specification
+    */
+   _addSpec (spec) {
+     //
+     // TODO(sbw): It's important to add endpoints with templating before adding
+     // any endpoints with paths that are subpaths of templated paths.
+     //
+     // E.g., add /api/v1/namepaces/{namespace} before adding /api/v1/namepaces
+     //
+     // This is important because ._addEndpoint constructs Component objects on
+     // demand, and Component requires specifying if it's templated or not. If we
+     // cause ._addEndpoint to construct a un-templated Component, templated
+     // operations that share the Components subpath will not work.
+     //
+     Object.keys(spec.paths)
+       .map(name => {
+         const leadingAndTrailingSlashes = /(^\/)|(\/$)/g
+         const splits = name.replace(leadingAndTrailingSlashes, '').split('/')
+         return new Endpoint({ name, splits, pathItem: spec.paths[name] })
+       })
+       .sort((endpoint0, endpoint1) => {
+         return endpoint1.splits.length - endpoint0.splits.length
+       }).forEach(endpoint => {
+         this._addEndpoint(endpoint)
+       })
+   }
+ 
+   _addChild (split, component) {
+     this.getNames(split, this.splits).forEach(name => {
+       this[name] = component
+       this.children.push(name)
+     })
+   }
+ 
+   _walkSplits (endpoint) {
+     const splits = this.splits.slice()
+     // This splits an endpoint on the '/' character. 
+     // Example: /apis/custom.metrics.k8s.io/v1beta1/{resource}/{name}/{subresource}
+     // Splits would be: api, custom.metrics.k8s.io, v1beta1, resource, name, subresource
+     const nextSplits = endpoint.splits.slice()
+ 
+     let parent = this
+     while (nextSplits.length) {
+       const split = nextSplits.shift()
+       splits.push(split)
+ 
+       let template = null
+       if (nextSplits.length && nextSplits[0].startsWith('{')) {
+         template = nextSplits.shift().slice(1, -1)
+       }
 
-class Endpoint {
-  /**
-   * Internal representation of a Swagger Path Item Object.
-   * @param {object} options - Options object
-   * @param {string} options.name - Path Item Object name
-   * @param {array} options.splits - Pathname pieces split in '/'
-   * @param {object} options.pathItem - Swagger Path Item Object.
-   */
-  constructor (options) {
-    this.name = options.name
-    this.splits = options.splits
-    this.pathItem = options.pathItem
-  }
-}
+       // Example: '/apis/custom.metrics.k8s.io/v1beta1/namespaces/{namespace}/{resource}/{name}/{subresource}'
+       // Checks if current split, such as 'v1beta' is already in the parent object, i.e
+       // 'custom.metrics.k8s.io'
+       // If it isn't, we construct an object and add 'v1beta' along with the params
+       // as a child of 'custom.metrics.k8s.io'.
+       // In this example, it would add a child under 'v1beta1' for 'namespaces'
+       if (!(split in parent)) {
+         const component = new this.constructor({
+           getNames: this.getNames,
+           backend: this.backend,
+           parameters: this.parameters,
+           templated: Boolean(template),
+           splits
+         })
+         parent._addChild(split, component)
+       }
+       // However, in case of new API endpoints such as "/apis/custom.metrics.k8s.io/v1beta1/{resource}/{name}/{subresource}", 
+       // the 'this' object for 'v1beta1' should be switched from templated=false to templated=true,
+       // since the next-split {resource} is a templated parameter.
+       // The variable templatedEndpoints, whis is null for non-templated parents also has to be
+       // switched to hold a list as we'll be pushing endpoints into it in this case.
+       else if (!parent[split].templated  && Boolean(template)) {
+        parent[split].templatedEndpoints = []
+        parent[split].templated = true
+       }
+       parent = parent[split]
 
-class Component {
-  /**
-   * Represents a single path split, child Components, and potentially a Path
-   * Item Object.
-   * @param {object} options - Options object
-   * @param {object} options.http - Request object
-   * @param {array} options.splits - Absolute pathname (split on '/')
-   * @param {string} options.parameters - Path Template values for parents
-   * @param {string} options.template - Optional Path Template (e.g., {name})
-   */
-  constructor (options) {
-    options = Object.assign({ splits: [], parameters: [] }, options)
-    let component
-
-    //
-    // Support Path Templating: use a function to create a a Component-like
-    // object if required. Otherwise use a vanilla object (that isn't callable).
-    //
-    if (options.templated) {
-      component = name => {
-        const splits = component.splits.concat([name])
-        //
-        // Assume that we'll never have a path with adjacent templates.
-        // E.g., assume `/foo/{name}/{property}` cannot exist.
-        //
-        const namedComponent = new this.constructor({
-          backend: component.backend,
-          getNames: options.getNames,
-          splits: splits,
-          parameters: options.parameters.concat([name])
-        })
-        component.templatedEndpoints.forEach(child => {
-          namedComponent._addEndpoint(child)
-        })
-        return namedComponent
-      }
-      component.templatedEndpoints = []
-
-      //
-      // Attach methods
-      //
-      Object.setPrototypeOf(component, this.constructor.prototype)
-    } else {
-      component = this
-      component.templatedEndpoints = null
-    }
-
-    component.parameters = options.parameters
-    component.templated = options.templated
-    component.splits = options.splits.slice()
-    component.backend = options.backend
-    component.getNames = options.getNames || (split => [split])
-    component.children = []
-    return component
-  }
-
-  /**
-   * Get the path.
-   * @returns {string} path with '/' as the separator.
-   */
-  getPath () {
-    return `/${this.splits.join('/')}`
-  }
-
-  /**
-   * Return an object of pathname parameters.
-   * @returns {object} object mapping each parameter name to its value.
-   */
-  getPathnameParameters () {
-    const pathnameParameterNames = this.swaggerName
-      .split('/')
-      .filter(component => component.startsWith('{'))
-      .map(component => component.slice(1, -1))
-
-    return pathnameParameterNames.reduce((acc, value, index) => {
-      acc[value] = this.parameters[index]
-      return acc
-    }, {})
-  }
-
-  /**
-   * Add endpoints defined by a swagger spec to this component. You would
-   * typically call this only on the root component to add API resources. For
-   * example, during client initialization, to extend the client with CRDs.
-   * @param {object} spec - Swagger specification
-   */
-  _addSpec (spec) {
-    //
-    // TODO(sbw): It's important to add endpoints with templating before adding
-    // any endpoints with paths that are subpaths of templated paths.
-    //
-    // E.g., add /api/v1/namepaces/{namespace} before adding /api/v1/namepaces
-    //
-    // This is important because ._addEndpoint constructs Component objects on
-    // demand, and Component requires specifying if it's templated or not. If we
-    // cause ._addEndpoint to construct a un-templated Component, templated
-    // operations that share the Components subpath will not work.
-    //
-    Object.keys(spec.paths)
-      .map(name => {
-        const leadingAndTrailingSlashes = /(^\/)|(\/$)/g
-        const splits = name.replace(leadingAndTrailingSlashes, '').split('/')
-        return new Endpoint({ name, splits, pathItem: spec.paths[name] })
-      })
-      .sort((endpoint0, endpoint1) => {
-        return endpoint1.splits.length - endpoint0.splits.length
-      }).forEach(endpoint => {
-        this._addEndpoint(endpoint)
-      })
-  }
-
-  _addChild (split, component) {
-    this.getNames(split, this.splits).forEach(name => {
-      this[name] = component
-      this.children.push(name)
-    })
-  }
-
-  _walkSplits (endpoint) {
-    const splits = this.splits.slice()
-    const nextSplits = endpoint.splits.slice()
-    const group = nextSplits[1]
-
-    let parent = this
-    while (nextSplits.length) {
-      const split = nextSplits.shift()
-      splits.push(split)
-
-      let template = null
-      if (nextSplits.length && nextSplits[0].startsWith('{')) {
-        template = nextSplits.shift().slice(1, -1)
-      }
-
-      if (!(split in parent)) {
-        const component = new this.constructor({
-          getNames: this.getNames,
-          backend: this.backend,
-          parameters: this.parameters,
-          templated: Boolean(template),
-          splits
-        })
-        parent._addChild(split, component)
-      }
-      parent = parent[split]
-
-      //
-      // We need to skip the check for parent.templated for API endpoints such as
-      // "/apis/custom.metrics.k8s.io/v1beta1/{resource}/{name}/{subresource}"
-      // since the parent of {resource} is a 'version' and is never templated.
-      //
-      let split_index = splits.indexOf(split)
-      let prev_split
-      if (split_index!=0) {
-        prev_split = splits[split_index - 1]
-      }
-
-      //
-      // Path Template: save it and walk it once the user specifies
-      // the value.
-      //
-      if (template && prev_split != group) {
-        if (!parent.templated) {
-          throw new Error('Created Component, but require templated one. ' +
+       //
+       // Path Template: save it and walk it once the user specifies
+       // the value.
+       // Basically stop iteration when we encounter a {templated} path item
+       //  and add the endpoint to the parent object at this point.
+       if (template) {
+         if (!parent.templated) {
+          throw new Error('Created Component, but require templated one. Endpoint: ' + endpoint.name +
                           'This is a bug. Please report: ' +
                           'https://github.com/silasbw/fluent-openapi/issues')
-        }
-        parent.templatedEndpoints.push(new Endpoint({
-          name: endpoint.name,
-          splits: nextSplits,
-          pathItem: endpoint.pathItem
-        }))
-        return null
-      }
-    }
-    return parent
-  }
-
-  /**
-   * Add an Endpoint by creating an object chain according to its pathname
-   * splits; and adding operations according to the pathItem.
-   * @param {Endpoint} endpoint - Endpoint object.
-   * @returns {Component} Component object endpoint was added to.
-   */
-  _addEndpoint (endpoint) {
-    const component = this._walkSplits(endpoint)
-    if (!component) return null
-    component.pathItemObject = endpoint.pathItem
-    component.swaggerName = endpoint.name
-
-    //
-    // "Expose" operations by omitting the leading _ from the method name.
-    //
-    const supportedMethods = ['get', 'put', 'post', 'delete', 'patch']
-
-    supportedMethods
-      .filter(method => endpoint.pathItem[method])
-      .forEach(method => {
-        component[method] = component['_' + method]
-        if (method === 'get') component.getStream = component._getStream
-      })
-
-    return component
-  }
-
-  /**
-   * Invoke a REST method
-   * @param {string} method - HTTP method
-   * @param {ApiRequestOptions} options - Options object
-   * @returns {(Promise|Stream)} Promise
-   */
-  _requestAsync (method, options) {
-    return this.backend.http(Object.assign({
-      method,
-      pathItemObject: this.pathItemObject,
-      pathname: this.getPath(),
-      pathnameParameters: this.getPathnameParameters()
-    }, options))
-  }
-
-  //
-  // Supported operations.
-  //
-
-  /**
-   * Invoke a GET request against the API server
-   * @param {ApiRequestOptions} options - Options object.
-   * @returns {Stream} Stream
-   */
-  _getStream (options) {
-    return this._requestAsync('GET', Object.assign({ stream: true }, options))
-  }
-
-  /**
-   * Invoke a GET request against the API server
-   * @param {ApiRequestOptions} options - Options object.
-   * @returns {Promise} Promise
-   */
-  _get (options) {
-    return this._requestAsync('GET', options)
-  }
-
-  /**
-   * Invoke a DELETE request against the API server
-   * @param {ApiRequestOptions} options - Options object.
-   * @returns {Promise} Promise
-   */
-  _delete (options) {
-    return this._requestAsync('DELETE', options)
-  }
-
-  /**
-   * Invoke a PATCH request against the API server
-   * @param {ApiRequestOptions} options - Options object
-   * @returns {Promise} Promise
-   */
-  _patch (options) {
-    return this._requestAsync('PATCH', merge({
-      headers: { 'content-type': 'application/strategic-merge-patch+json' }
-    }, options, { isMergeableObject: isPlainObject }))
-  }
-
-  /**
-   * Invoke a POST request against the API server
-   * @param {ApiRequestOptions} options - Options object
-   * @returns {Promise} Promise
-   */
-  _post (options) {
-    return this._requestAsync('POST', merge({
-      headers: { 'content-type': 'application/json' }
-    }, options, { isMergeableObject: isPlainObject }))
-  }
-
-  /**
-   * Invoke a PUT request against the API server
-   * @param {ApiRequestOptions} options - Options object
-   * @returns {Promise} Promise
-   */
-  _put (options) {
-    return this._requestAsync('PUT', merge({
-      headers: { 'content-type': 'application/json' }
-    }, options, { isMergeableObject: isPlainObject }))
-  }
-}
-
-module.exports = Component
+         }
+         parent.templatedEndpoints.push(new Endpoint({
+           name: endpoint.name,
+           splits: nextSplits,
+           pathItem: endpoint.pathItem
+         }))
+         return null
+       }
+     }
+     return parent
+   }
+ 
+   /**
+    * Add an Endpoint by creating an object chain according to its pathname
+    * splits; and adding operations according to the pathItem.
+    * @param {Endpoint} endpoint - Endpoint object.
+    * @returns {Component} Component object endpoint was added to.
+    */
+   _addEndpoint (endpoint) {
+     const component = this._walkSplits(endpoint)
+     if (!component) return null
+     component.pathItemObject = endpoint.pathItem
+     component.swaggerName = endpoint.name
+ 
+     //
+     // "Expose" operations by omitting the leading _ from the method name.
+     //
+     const supportedMethods = ['get', 'put', 'post', 'delete', 'patch']
+ 
+     supportedMethods
+       .filter(method => endpoint.pathItem[method])
+       .forEach(method => {
+         component[method] = component['_' + method]
+         if (method === 'get') component.getStream = component._getStream
+       })
+ 
+     return component
+   }
+ 
+   /**
+    * Invoke a REST method
+    * @param {string} method - HTTP method
+    * @param {ApiRequestOptions} options - Options object
+    * @returns {(Promise|Stream)} Promise
+    */
+   _requestAsync (method, options) {
+     return this.backend.http(Object.assign({
+       method,
+       pathItemObject: this.pathItemObject,
+       pathname: this.getPath(),
+       pathnameParameters: this.getPathnameParameters()
+     }, options))
+   }
+ 
+   //
+   // Supported operations.
+   //
+ 
+   /**
+    * Invoke a GET request against the API server
+    * @param {ApiRequestOptions} options - Options object.
+    * @returns {Stream} Stream
+    */
+   _getStream (options) {
+     return this._requestAsync('GET', Object.assign({ stream: true }, options))
+   }
+ 
+   /**
+    * Invoke a GET request against the API server
+    * @param {ApiRequestOptions} options - Options object.
+    * @returns {Promise} Promise
+    */
+   _get (options) {
+     return this._requestAsync('GET', options)
+   }
+ 
+   /**
+    * Invoke a DELETE request against the API server
+    * @param {ApiRequestOptions} options - Options object.
+    * @returns {Promise} Promise
+    */
+   _delete (options) {
+     return this._requestAsync('DELETE', options)
+   }
+ 
+   /**
+    * Invoke a PATCH request against the API server
+    * @param {ApiRequestOptions} options - Options object
+    * @returns {Promise} Promise
+    */
+   _patch (options) {
+     return this._requestAsync('PATCH', merge({
+       headers: { 'content-type': 'application/strategic-merge-patch+json' }
+     }, options, { isMergeableObject: isPlainObject }))
+   }
+ 
+   /**
+    * Invoke a POST request against the API server
+    * @param {ApiRequestOptions} options - Options object
+    * @returns {Promise} Promise
+    */
+   _post (options) {
+     return this._requestAsync('POST', merge({
+       headers: { 'content-type': 'application/json' }
+     }, options, { isMergeableObject: isPlainObject }))
+   }
+ 
+   /**
+    * Invoke a PUT request against the API server
+    * @param {ApiRequestOptions} options - Options object
+    * @returns {Promise} Promise
+    */
+   _put (options) {
+     return this._requestAsync('PUT', merge({
+       headers: { 'content-type': 'application/json' }
+     }, options, { isMergeableObject: isPlainObject }))
+   }
+ }
+ 
+ module.exports = Component
+ 

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -161,6 +161,7 @@ class Component {
   _walkSplits (endpoint) {
     const splits = this.splits.slice()
     const nextSplits = endpoint.splits.slice()
+    const group = nextSplits[1]
 
     let parent = this
     while (nextSplits.length) {
@@ -185,10 +186,21 @@ class Component {
       parent = parent[split]
 
       //
+      // We need to skip the check for parent.templated for API endpoints such as
+      // "/apis/custom.metrics.k8s.io/v1beta1/{resource}/{name}/{subresource}"
+      // since the parent of {resource} is a 'version' and is never templated.
+      //
+      const split_index = splits.indexOf(split)
+      const prev_split
+      if (split_index!=0) {
+        prev_split = splits[split_index - 1]
+      }
+
+      //
       // Path Template: save it and walk it once the user specifies
       // the value.
       //
-      if (template) {
+      if (template && prev_split != group) {
         if (!parent.templated) {
           throw new Error('Created Component, but require templated one. ' +
                           'This is a bug. Please report: ' +

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -190,8 +190,8 @@ class Component {
       // "/apis/custom.metrics.k8s.io/v1beta1/{resource}/{name}/{subresource}"
       // since the parent of {resource} is a 'version' and is never templated.
       //
-      const split_index = splits.indexOf(split)
-      const prev_split
+      let split_index = splits.indexOf(split)
+      let prev_split
       if (split_index!=0) {
         prev_split = splits[split_index - 1]
       }

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -332,4 +332,3 @@
  }
  
  module.exports = Component
- 


### PR DESCRIPTION
This should fix https://github.com/silasbw/swagger-fluent/issues/55 and a few upstream project issues such as this: https://github.com/external-secrets/kubernetes-external-secrets/issues/576

**Fair bit of WARNING** that I'm nowhere even remotely close to having any JS knowledge, so while this code works for me, it might either be a terrible implementation or a buggy one for other projects. Please feel free to fix as you see fit.

The reason this fix is required is due to projects such as 'kube-metrics-adapter' creating a couple of new API endpoints. If you fetch the openapi spec:
`kubectl get --raw /openapi/v2`



you'll see that two problematic custom.metrics endpoints have a templated parameter right after 'version'. No other API in the spec has this behaviour. 

```
		},
		"/apis/custom.metrics.k8s.io/v1beta1/{resource}/{name}/{subresource}": {
			"get": {
                .
                .
                .
		},
		"/apis/custom.metrics.k8s.io/v1beta2/{resource}/{name}/{subresource}": {
			"get": {
```

Side note, I noticed none of the custom.metrics or external.metrics endpoints carry a version object either. Other endpoints carry this information in the `"x-kubernetes-group-version-kind"` field, for example:
```
				"x-kubernetes-group-version-kind": {
					"group": "discovery.k8s.io",
					"kind": "EndpointSlice",
					"version": "v1beta1"
				}
```

The fix in the PR assigns variable 'group' to list item [1] in an array that looks like 'splits' below:

```
  name: '/apis/custom.metrics.k8s.io/v1beta1/{resource}/{name}/{subresource}',
  splits: [
    'apis',
    'custom.metrics.k8s.io',
    'v1beta1',
    '{resource}',
    '{name}',
    '{subresource}'
  ],
```

The fix then ignores if the parent of the current templated 'split' matches the 'group' variable, since a 'group' would never be a templated split.

Here's the entire json for one of the two problematic endpoints, in case you were curious:

```
		"/apis/custom.metrics.k8s.io/v1beta1/{resource}/{name}/{subresource}": {
			"get": {
				"description": "list custom metrics describing an object or objects",
				"consumes": ["*/*"],
				"produces": ["application/json", "application/yaml", "application/vnd.kubernetes.protobuf", "application/json;stream=watch", "application/vnd.kubernetes.protobuf;stream=watch"],
				"schemes": ["https"],
				"tags": ["customMetrics_v1beta1"],
				"operationId": "listCustomMetricsV1beta1MetricValue",
				"responses": {
					"200": {
						"description": "OK",
						"schema": {
							"$ref": "#/definitions/io.k8s.metrics.pkg.apis.custom_metrics.v1beta1.MetricValueList"
						}
					}
				}
			},
			"parameters": [{
				"uniqueItems": true,
				"type": "boolean",
				"description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored. If the feature gate WatchBookmarks is not enabled in apiserver, this field is ignored.",
				"name": "allowWatchBookmarks",
				"in": "query"
			}, {
				"uniqueItems": true,
				"type": "string",
				"description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
				"name": "continue",
				"in": "query"
			}, {
				"uniqueItems": true,
				"type": "string",
				"description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
				"name": "fieldSelector",
				"in": "query"
			}, {
				"uniqueItems": true,
				"type": "string",
				"description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
				"name": "labelSelector",
				"in": "query"
			}, {
				"uniqueItems": true,
				"type": "integer",
				"description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
				"name": "limit",
				"in": "query"
			}, {
				"uniqueItems": true,
				"type": "string",
				"name": "metricLabelSelector",
				"in": "query"
			}, {
				"uniqueItems": true,
				"type": "string",
				"description": "name of the described resource",
				"name": "name",
				"in": "path",
				"required": true
			}, {
				"uniqueItems": true,
				"type": "string",
				"description": "If 'true', then the output is pretty printed.",
				"name": "pretty",
				"in": "query"
			}, {
				"uniqueItems": true,
				"type": "string",
				"description": "the name of the resource",
				"name": "resource",
				"in": "path",
				"required": true
			}, {
				"uniqueItems": true,
				"type": "string",
				"description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
				"name": "resourceVersion",
				"in": "query"
			}, {
				"uniqueItems": true,
				"type": "string",
				"description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
				"name": "resourceVersionMatch",
				"in": "query"
			}, {
				"uniqueItems": true,
				"type": "string",
				"description": "the name of the subresource",
				"name": "subresource",
				"in": "path",
				"required": true
			}, {
				"uniqueItems": true,
				"type": "integer",
				"description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
				"name": "timeoutSeconds",
				"in": "query"
			}, {
				"uniqueItems": true,
				"type": "boolean",
				"description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
				"name": "watch",
				"in": "query"
			}]
		},
```